### PR TITLE
Fix various typing issues.

### DIFF
--- a/cogs/developer.py
+++ b/cogs/developer.py
@@ -1,19 +1,26 @@
+from __future__ import annotations
+
 import os
 
 import discord
 import ext.helpers as helpers
 from discord.ext import commands
+from typing import TYPE_CHECKING, Dict, List, Mapping
+
+if TYPE_CHECKING:
+    from ext.models import CodingBot
+    from types import ModuleType
 
 
 class Developer(commands.Cog, command_attrs=dict(hidden=True)):
 
     hidden = True
 
-    def __init__(self, bot):
+    def __init__(self, bot: CodingBot):
         self.bot = bot
 
     @commands.command(name="sync")
-    async def sync(self, ctx):
+    async def sync(self, ctx: commands.Context[CodingBot]):
         """
         Sync the database
         """
@@ -22,7 +29,7 @@ class Developer(commands.Cog, command_attrs=dict(hidden=True)):
 
     @commands.command(name='load', aliases=['l'])
     @commands.is_owner()
-    async def _load(self, ctx, cog_, save: bool = False):
+    async def _load(self, ctx: commands.Context[CodingBot], cog_: str, save: bool = False):
         if save:
             helpers.storage(self.bot, key='cogs', value=cog_, method='append')
         await self.bot.load_extension(cog_)
@@ -34,7 +41,7 @@ class Developer(commands.Cog, command_attrs=dict(hidden=True)):
 
     @commands.command(name='unload', aliases=['u'])
     @commands.is_owner()
-    async def _unload(self, ctx, cog_, save: bool = False):
+    async def _unload(self, ctx: commands.Context[CodingBot], cog_: str, save: bool = False):
         if save:
             helpers.storage(self.bot, key='cogs', value=cog_, method='remove')
         await self.bot.unload_extension(cog_)
@@ -46,16 +53,16 @@ class Developer(commands.Cog, command_attrs=dict(hidden=True)):
 
     @commands.command(name='reload', aliases=['r'])
     @commands.is_owner()
-    async def _reload(self, ctx, cog_):
-        self.bot.reload_extension(cog_)
+    async def _reload(self, ctx: commands.Context[CodingBot], cog_: str):
+        await self.bot.reload_extension(cog_)
         embed = discord.Embed(title='Success', color=discord.Color.green())
         await ctx.send(embed=embed)
 
     @commands.command(name='loadall', aliases=['la'])
     @commands.is_owner()
-    async def _loadall(self, ctx):
+    async def _loadall(self, ctx: commands.Context[CodingBot]):
         data = os.listdir('./cogs')
-        cogs = {
+        cogs: Dict[str, List[str]] = {
             'loaded': [],
             'not': []
         }
@@ -76,12 +83,12 @@ class Developer(commands.Cog, command_attrs=dict(hidden=True)):
 
     @commands.command(name='unloadall', aliases=['ua', 'uall'])
     @commands.is_owner()
-    async def _unloadall(self, ctx):
-        cogs = {
+    async def _unloadall(self, ctx: commands.Context[CodingBot]):
+        cogs: Dict[str, List[str]] = {
             'unloaded': [],
             'not': []
         }
-        processing = self.bot.extensions.copy()
+        processing: Mapping[str, ModuleType] = self.bot.extensions.copy()  # type: ignore
         for cog in processing:
             try:
                 await self.bot.unload_extension(cog)
@@ -95,12 +102,12 @@ class Developer(commands.Cog, command_attrs=dict(hidden=True)):
 
     @commands.command(name='reloadall', aliases=['ra', 'rall'])
     @commands.is_owner()
-    async def _reloadall(self, ctx):
-        cogs = {
+    async def _reloadall(self, ctx: commands.Context[CodingBot]):
+        cogs: Dict[str, List[str]] = {
             'reloaded': [],
             'not': []
         }
-        processing = self.bot.extensions.copy()
+        processing: Mapping[str, ModuleType] = self.bot.extensions.copy()  # type: ignore
         print(processing)
         for cog in processing:
             try:
@@ -115,5 +122,5 @@ class Developer(commands.Cog, command_attrs=dict(hidden=True)):
         await ctx.send(embed=embed)
 
 
-async def setup(bot):
+async def setup(bot: CodingBot):
     await bot.add_cog(Developer(bot))

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,18 +1,24 @@
+from __future__ import annotations
+
 import random
 
 import discord
 from discord.ext import commands
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ext.models import CodingBot
 
 
 class Fun(commands.Cog, command_attrs=dict(hidden=False)):
 
     hidden = False
 
-    def __init__(self, bot):
+    def __init__(self, bot: CodingBot):
         self.bot = bot
 
     @commands.hybrid_command(name="meme")
-    async def meme(self, ctx: commands.Context):
+    async def meme(self, ctx: commands.Context[CodingBot]):
         response = await self.bot.session.get("https://meme-api.herokuapp.com/gimme")
         meme_json = await response.json()
 
@@ -28,7 +34,7 @@ class Fun(commands.Cog, command_attrs=dict(hidden=False)):
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="8ball")
-    async def eightball(self, ctx: commands.Context, *, question: str):
+    async def eightball(self, ctx: commands.Context[CodingBot], *, question: str):
         responses = ["As I see it, yes.", "Ask again later.", "Better not tell you now.", "Cannot predict now.", "Concentrate and ask again.",
                      "Do not count on it.", "It is certain.", "It is decidedly so.", "Most likely.", "My reply is no.", "My sources say no.",
                      "Outlook not so good.", "Outlook good.", "Reply hazy, try again.", "Signs point to yes.", "Very doubtful.", "Without a doubt.",
@@ -43,7 +49,7 @@ class Fun(commands.Cog, command_attrs=dict(hidden=False)):
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="token")
-    async def token(self, ctx: commands.Context):
+    async def token(self, ctx: commands.Context[CodingBot]):
         # If you like, you can use sr_api
         response = await self.bot.session.get("https://some-random-api.ml/bottoken")
         json = await response.json()
@@ -57,7 +63,7 @@ class Fun(commands.Cog, command_attrs=dict(hidden=False)):
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="animal")
-    async def animal(self, ctx: commands.Context, animal: str = None):
+    async def animal(self, ctx: commands.Context[CodingBot], animal: Optional[str] = None):
         options = ("dog", "cat", "panda", "fox", "red_panda",
                    "koala", "bird", "raccoon", "kangaroo")
         if (not animal) or (animal and animal not in options):
@@ -82,5 +88,5 @@ class Fun(commands.Cog, command_attrs=dict(hidden=False)):
     # DO YOUR COMMANDS HERE I HAVE NOT ENOUGH CREATIVITY TO THINK ABOUT THEM KEKW
 
 
-async def setup(bot):
+async def setup(bot: CodingBot):
     await bot.add_cog(Fun(bot))

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -1,33 +1,42 @@
+from __future__ import annotations
+
 import random
-import time
 
 import discord
 from discord.ext import commands
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ext.models import CodingBot
+
 
 class Misc(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: CodingBot):
         self.bot = bot
 
     @commands.hybrid_command(name="afk", aliases = ["afk-set", "set-afk"], help = "Sets your afk")
-
     @commands.cooldown(1, 10, commands.BucketType.member)
-    async def afk(self, ctx: commands.Context, *, reason: str = None):
+    async def afk(self, ctx: commands.Context[CodingBot], *, reason: Optional[str] = None):
+        assert isinstance(ctx.author, discord.Member)
+        assert ctx.guild is not None
+
         if not reason:
             reason = "AFK"
         member = ctx.author
         staff_role = ctx.guild.get_role(795145820210462771)
         on_pat_staff = member.guild.get_role(726441123966484600) # "on_patrol_staff" role
+
         if staff_role in member.roles:
             try:
-                await member.remove_roles(on_pat_staff)
+                await member.remove_roles(on_pat_staff)  # type: ignore
             except (discord.Forbidden, discord.HTTPException):
                 pass
         record = await self.bot.conn.select_record(
                 'afk',
                 table='afk',
-                arguments=['afk_time', 'reason'],
-                where=['user_id'],
-                values=[member.id]
+                arguments=('afk_time', 'reason'),
+                where=('user_id',),
+                values=(member.id,),
             )
         if not record:
             await self.bot.conn.insert_record(
@@ -40,6 +49,7 @@ class Misc(commands.Cog):
                 await member.edit(nick=f"[AFK] {member.display_name}")
             except:
                 pass
+
             emoji = random.choice(['⚪','🔴','🟤','🟣','🟢','🟡','🟠','🔵'])
             embed = discord.Embed(
                 description=f"{emoji} I set your AFK: {reason}",
@@ -53,5 +63,5 @@ class Misc(commands.Cog):
             )
             await ctx.reply(embed=embed, ephemeral=True)
 
-async def setup(bot):
+async def setup(bot: CodingBot):
     await bot.add_cog(Misc(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import datetime
 from io import BytesIO
@@ -9,13 +11,18 @@ from discord.ext import commands
 from ext.errors import InsufficientPrivilegeError
 from ext.models import TimeConverter
 from ext.ui.view import ConfirmButton
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ext.models import CodingBot
+
 
 
 def trainee_check():
-    def wrapper(ctx: commands.Context):
-        trainee_role = ctx.guild.get_role(729537643951554583)
+    def wrapper(ctx: commands.Context[CodingBot]):
+        trainee_role = ctx.guild.get_role(729537643951554583)  # type: ignore
         if trainee_role:
-            if ctx.author.top_role.position >= trainee_role.position:
+            if ctx.author.top_role.position >= trainee_role.position:  # type: ignore
                 return True
         raise InsufficientPrivilegeError(
             "{}, you don't have the permission to use this command.".format(ctx.author.mention))
@@ -26,12 +33,15 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
 
     hidden = False
 
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: CodingBot):
         self.bot = bot
 
-    def check_member_permission(self, ctx, member):
+    def check_member_permission(self, ctx: commands.Context[CodingBot], member: Union[discord.User, discord.Member]):
         if isinstance(member, discord.User):
             return False
+        assert ctx.guild is not None
+        assert ctx.command is not None
+
         if ctx.author.top_role.position <= member.top_role.position and ctx.author != ctx.guild.owner:
             return f"You can't {ctx.command.name} this member. They have a higher or equal role than you."
         elif member == ctx.author:
@@ -39,15 +49,17 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
         elif member == ctx.guild.owner:
             return f"You can't {ctx.command.name} the server owner."
 
-    async def capture_evidence(self, ctx) -> Optional[discord.Attachment]:
+        return False
+
+    async def capture_evidence(self, ctx: commands.Context[CodingBot]) -> Optional[discord.Attachment]:
         view = ConfirmButton(ctx)
         view.message = await ctx.author.send(f'Do you want to provide an evidence for your action?', view=view)
         view_touched = not (await view.wait())
         evidence_byts = None
         if view_touched:
             if view.confirmed:
+                initial_mess = await ctx.author.send("Please send the evidence in the form of an attachment.")
                 try:
-                    initial_mess = await ctx.author.send("Please send the evidence in the form of an attachment.")
                     wait_mess = await self.bot.wait_for(
                         'message', check=lambda m: m.author == ctx.author and m.channel == initial_mess.channel and m.attachments and not m.guild, timeout=60
                     )
@@ -66,7 +78,7 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
                   moderator: discord.Member,
                   reason: str = 'No reason was provided',
                   duration: Optional[datetime.timedelta] = None,
-                  **kwargs: Dict[str, Any]
+                  **kwargs: Any,
                   ) -> None:
         """
         A function that logs all moderation commands executed
@@ -86,7 +98,7 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
         duration : Optional[datetime.timedelta]
             The duration of the action
         """
-        definition = {
+        definition: Dict[str, Any] = {
             'ban': {
                 'action': 'banned',
                 'undo_action': 'unbanned',
@@ -118,6 +130,7 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
         if action not in definition:
             raise ValueError(f"Invalid action {action}")
         action_info = definition.get(action)
+        assert action_info is not None
         if undo and isinstance(action_info.get('undo_action'), ValueError):
             raise action_info.get('undo_action')
 
@@ -146,11 +159,12 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
             name=f'{moderator} (ID: {moderator.id})', icon_url=moderator.display_avatar.url)
         embed.set_thumbnail(url=member.display_avatar.url)
         logs = self.bot.get_channel(964165082437263361)  # 816512034228666419
-        await logs.send(embed=embed, file=file)
+        await logs.send(embed=embed, file=file)  # type: ignore
 
     @commands.hybrid_command(name="kick")
     @commands.has_permissions(kick_members=True)
-    async def kick(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
+    async def kick(self, ctx: commands.Context[CodingBot], member: discord.Member, *, reason: Optional[str] = None):
+        assert ctx.guild is not None
         check_made = self.check_member_permission(ctx, member)
         if check_made:
             return await ctx.send(check_made)
@@ -163,11 +177,12 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
             await member.kick(reason=reason)
             await ctx.send(f'Kicked {member.mention}')
             evidence = await self.capture_evidence(ctx)
-            await self.log(action='kick', moderator=ctx.author, member=member, reason=reason, evidence=evidence)
+            await self.log(action='kick', moderator=ctx.author, member=member, reason=reason, evidence=evidence)  # type: ignore
 
     @commands.hybrid_command(name="ban")
     @commands.has_permissions(ban_members=True)
-    async def ban(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
+    async def ban(self, ctx: commands.Context[CodingBot], member: discord.Member, *, reason: Optional[str] = None):
+        assert ctx.guild is not None
         check_made = self.check_member_permission(ctx, member)
         if check_made:
             return await ctx.send(check_made)
@@ -180,22 +195,24 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
         else:
             await member.ban(reason=reason, delete_message_days=7)
             await ctx.send(f'Banned {member.mention}')
-            await self.log(action='ban', moderator=ctx.author, member=member, undo=False, reason=reason, duration=None, evidence=evidence)
+            await self.log(action='ban', moderator=ctx.author, member=member, undo=False, reason=reason, duration=None, evidence=evidence)  # type: ignore
 
     @commands.hybrid_command(name="unban")
     @commands.has_permissions(ban_members=True)
-    async def unban(self, ctx: commands.Context, user: discord.User, *, reason: str = None):
+    async def unban(self, ctx: commands.Context[CodingBot], user: discord.User, *, reason: Optional[str] = None):
+        assert ctx.guild is not None
         try:
             await ctx.guild.unban(user)
         except discord.NotFound:
             return await ctx.send(f'{user.mention} is not banned from this server.')
         else:
             await ctx.send(f'Unbanned {user.mention}')
-            await self.log(action='ban', moderator=ctx.author, member=user, undo=True, reason=reason, duration=None)
+            await self.log(action='ban', moderator=ctx.author, member=user, undo=True, reason=reason, duration=None)  # type: ignore
 
     @commands.hybrid_command(name="mute", aliases=['timeout'])
     @commands.has_permissions(manage_roles=True)
-    async def mute(self, ctx: commands.Context, member: discord.Member, duration: TimeConverter, *, reason: str = None):
+    async def mute(self, ctx: commands.Context[CodingBot], member: discord.Member, duration: TimeConverter, *, reason: Optional[str] = None):
+        assert ctx.guild is not None
         check_made = self.check_member_permission(ctx, member)
         if check_made:
             return await ctx.send(check_made)
@@ -206,15 +223,15 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
         except discord.Forbidden:
             pass
         else:
-            until = discord.utils.utcnow() + duration
+            until: datetime.datetime = discord.utils.utcnow() + duration  # type: ignore
             await member.timeout(until)
             await ctx.send(f'Muted {member.mention}')
             evidence = await self.capture_evidence(ctx)
-            await self.log(action='mute', moderator=ctx.author, member=member, undo=False, reason=reason, duration=duration, evidence=evidence)
+            await self.log(action='mute', moderator=ctx.author, member=member, undo=False, reason=reason, duration=duration, evidence=evidence)  # type: ignore
 
     @commands.hybrid_command(name="unmute")
     @commands.has_permissions(manage_roles=True)
-    async def unmute(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
+    async def unmute(self, ctx: commands.Context[CodingBot], member: discord.Member, *, reason: Optional[str] = None):
         check_made = self.check_member_permission(ctx, member)
         if check_made:
             return await ctx.send(check_made)
@@ -224,16 +241,16 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
             return await ctx.send(f'{member.mention} is not muted.')
         else:
             await ctx.send(f'Unmuted {member.mention}')
-            await self.log(action='mute', moderator=ctx.author, member=member, undo=True, reason=reason)
+            await self.log(action='mute', moderator=ctx.author, member=member, undo=True, reason=reason)  # type: ignore
 
     @commands.hybrid_command()
-    async def massban(self, ctx: commands.Context, users: commands.Greedy[Union[discord.Member, discord.User]]):
+    async def massban(self, ctx: commands.Context[CodingBot], users: commands.Greedy[Union[discord.Member, discord.User]]):
         if not users:
             return await ctx.send('Please provide at least one user to ban.')
-        users = set(users)
+        users = set(users)  # type: ignore
         if len(users) > 100:
             return await ctx.send('Please provide less than 100 users to ban.')
-        counter_dict = {
+        counter_dict: Dict[str, Any] = {
             'banned': [],
             'not_banned': []
         }
@@ -242,7 +259,7 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
             if check_made:
                 counter_dict['not_banned'].append(user)
                 continue
-            await ctx.guild.ban(user)
+            await ctx.guild.ban(user)  # type: ignore
             counter_dict['banned'].append(user)
         embed = discord.Embed(color=discord.Color.red())
         description = "Following members were banned:\n{}".format(
@@ -255,40 +272,42 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
 
 #    @trainee_check()
     @commands.hybrid_command()
-    async def warn(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
+    async def warn(self, ctx: commands.Context[CodingBot], member: discord.Member, *, reason: Optional[str] = None):
+        assert ctx.guild is not None
         if not reason:
             return await ctx.send("Please provide a reason for the warning.")
         await self.bot.conn.insert_record(
             'warnings',
             table='warnings',
-            columns=['guild_id', 'user_id', 'moderator_id', 'reason', 'date'],
-            values=[ctx.guild.id, member.id, ctx.author.id,
-                    reason, ctx.message.created_at.timestamp()]
+            columns=('guild_id', 'user_id', 'moderator_id', 'reason', 'date'),
+            values=(ctx.guild.id, member.id, ctx.author.id,
+                    reason, ctx.message.created_at.timestamp())
         )
         await ctx.send(f'Warned {member.mention}')
         evidence = await self.capture_evidence(ctx)
-        await self.log(action='warn', moderator=ctx.author, member=member, reason=reason, evidence=evidence)
+        await self.log(action='warn', moderator=ctx.author, member=member, reason=reason, evidence=evidence)  # type: ignore
 
 #    @trainee_check()
     @commands.hybrid_command(name="purge")
     @commands.has_permissions(manage_messages=True)
-    async def purge(self, ctx: commands.Context, amount: int = 1):
-        purged_amt = len(await ctx.channel.purge(limit=amount+1))
-        await ctx.send(f'Purged {purged_amt} messages in {ctx.channel.mention}')
+    async def purge(self, ctx: commands.Context[CodingBot], amount: int = 1):
+        purged_amt = len(await ctx.channel.purge(limit=amount + 1))  # type: ignore
+        await ctx.send(f'Purged {purged_amt} messages in {ctx.channel.mention}')  # type: ignore
 
 #    @trainee_check()
     @commands.command(name="warnings")
-    async def warnings(self, ctx: commands.Context, member: discord.Member):
+    async def warnings(self, ctx: commands.Context[CodingBot], member: discord.Member):
+        assert ctx.guild is not None
         embed = discord.Embed(
             title=f"{member} Warnings List", color=discord.Color.red())
         records = await self.bot.conn.select_record('warnings',
-                                                    arguments=[
-                                                        'reason', 'moderator_id', 'date'],
+                                                    arguments=(
+                                                        'reason', 'moderator_id', 'date'),
                                                     table='warnings',
-                                                    where=[
-                                                        'guild_id', 'user_id'],
+                                                    where=(
+                                                        'guild_id', 'user_id'),
                                                     values=(
-                                                        ctx.guild.id, member.id),
+                                                        ctx.guild.id, member.id),  # type: ignore
                                                     extras=[
                                                         'ORDER BY date DESC']
                                                     )
@@ -309,62 +328,62 @@ class Moderation(commands.Cog, command_attrs=dict(hidden=False)):
 #    @trainee_check()
     @commands.hybrid_command(name="clearwarning")
     @commands.has_permissions(manage_messages=True)
-    async def clearwarning(self, ctx: commands.Context, member: discord.Member = None, index: int = None):
-        member = member or ctx.author
+    async def clearwarning(self, ctx: commands.Context[CodingBot], member: Optional[discord.Member] = None, index: Optional[int] = None):
+        assert ctx.guild is not None
+        target: discord.Member = member or ctx.author  # type: ignore
         if index is None:
             await self.bot.conn.delete_record('warnings',
                                               table='warnings',
-                                              where=['guild_id', 'user_id'],
-                                              values=(ctx.guild.id, member.id)
+                                              where=('guild_id', 'user_id'),
+                                              values=(ctx.guild.id, target.id)
                                               )
         else:
             records = await self.bot.conn.select_record('warnings',
-                                                        arguments=['date'],
+                                                        arguments=('date',),
                                                         table='warnings',
-                                                        where=[
-                                                            'guild_id', 'user_id'],
+                                                        where=(
+                                                            'guild_id', 'user_id'),
                                                         values=(
-                                                            ctx.guild.id, member.id),
+                                                            ctx.guild.id, target.id),
                                                         extras=[
                                                             'ORDER BY date DESC']
                                                         )
 
             if not records:
-                return await ctx.send(f'{member.mention} has no warnings.')
+                return await ctx.send(f'{target.mention} has no warnings.')
 
             for i, sublist in enumerate(records, 1):
                 if index == i:
                     await self.bot.conn.delete_record('warnings',
                                                       table='warnings',
-                                                      where=[
-                                                          'guild_id', 'user_id', 'date'],
+                                                      where=(
+                                                          'guild_id', 'user_id', 'date'),
                                                       values=(
-                                                          ctx.guild.id, member.id, sublist.date)
+                                                          ctx.guild.id, target.id, sublist.date)
                                                       )
                     break
 
-        await ctx.reply(f'{member.mention}\'s warning was cleared.', allowed_mentions=discord.AllowedMentions(users=False))
-        await self.log(action='warn', moderator=ctx.author, member=member, undo=True)
+        await ctx.reply(f'{target.mention}\'s warning was cleared.', allowed_mentions=discord.AllowedMentions(users=False))
+        await self.log(action='warn', moderator=ctx.author, member=target, undo=True)  # type: ignore
 
     # FEEL FREE TO MOVE THIS TO ANY COGS (IF YOU ADD ONE)
 
     @commands.hybrid_command(name="whois")
-    async def whois(self, ctx: commands.Context, member: discord.Member = None):
-        if member is None:
-            member = ctx.author
+    async def whois(self, ctx: commands.Context[CodingBot], member: Optional[discord.Member] = None):
+        target: discord.Member = member or ctx.author  # type: ignore
         embed = discord.Embed(title=f"Showing user info : {member}")
-        embed.set_thumbnail(url=member.display_avatar.url)
+        embed.set_thumbnail(url=target.display_avatar.url)
         # Support for nitro users
         embed.set_footer(
             text=f"Requested by {ctx.author}", icon_url=ctx.author.display_avatar.url)
-        embed.add_field(name="Discord User ID", value=member.id, inline=False)
+        embed.add_field(name="Discord User ID", value=target.id, inline=False)
         embed.add_field(name="Account Created at",
-                        value=member.created_at, inline=False)
+                        value=target.created_at, inline=False)
         embed.add_field(name="Discord Joined at",
-                        value=member.joined_at, inline=False)
+                        value=target.joined_at, inline=False)
 
         await ctx.send(embed=embed)
 
 
-async def setup(bot):
+async def setup(bot: CodingBot):
     await bot.add_cog(Moderation(bot))

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import random
 
 import discord
 from discord.ext import commands, tasks
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ext.models import CodingBot
 
 
 class TaskCog(commands.Cog):
 
     hidden = True
 
-    def __init__(self, bot):
+    def __init__(self, bot: CodingBot):
         self.bot = bot
 
     async def cog_load(self) -> None:
@@ -29,10 +35,10 @@ class TaskCog(commands.Cog):
         if tcr:
             if tcr.get_role(795145820210462771):
                 statuses.append(random.choice(
-                    tcr.get_role(795145820210462771).members).name)
+                    tcr.get_role(795145820210462771).members).name)  # type: ignore
             if tcr.get_role(737517726737629214):
                 statuses.append(random.choice(tcr.get_role(
-                    737517726737629214).members).name + ' (Server Booster)')
+                    737517726737629214).members).name + ' (Server Booster)')  # type: ignore
 
         await self.bot.change_presence(activity=discord.Activity(
             type=discord.ActivityType.watching,
@@ -44,5 +50,5 @@ class TaskCog(commands.Cog):
         await self.bot.wait_until_ready()
 
 
-async def setup(bot):
+async def setup(bot: CodingBot):
     await bot.add_cog(TaskCog(bot))

--- a/ext/errors.py
+++ b/ext/errors.py
@@ -1,12 +1,14 @@
-from discord.ext.commands import CheckFailure
+from __future__ import annotations
+
+from discord.ext import commands
 
 
-class InsufficientPrivilegeError(CheckFailure):
+class InsufficientPrivilegeError(commands.CheckFailure):
     """
     Exception for insufficient privilege
     """
 
-    def __init__(self, message) -> None:
+    def __init__(self, message: str) -> None:
         self.message = message
 
     def __str__(self) -> str:

--- a/ext/ui/view.py
+++ b/ext/ui/view.py
@@ -1,9 +1,21 @@
+from __future__ import annotations
+
 import discord
 from discord import ui
 from discord.ext import commands
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ext.models import CodingBot
+    from typing_extensions import Self
+
+
 class ConfirmButton(ui.View):
-    def __init__(self, ctx: commands.Context) -> None:
+    if TYPE_CHECKING:
+        message: discord.Message
+
+    def __init__(self, ctx: commands.Context[CodingBot]) -> None:
         super().__init__(timeout=60)
         self.confirmed = None
         self.ctx = ctx
@@ -19,25 +31,25 @@ class ConfirmButton(ui.View):
 
     @ui.button(label='Yes', style=discord.ButtonStyle.green)
     async def confirm(
-        self, 
-        interaction: discord.Interaction, 
-        button: discord.Button
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button[Self],
     ) -> None:
         self.confirmed = True
         if interaction.message:
             await interaction.message.delete()
         else:
-            interaction.delete_original_message()
+            await interaction.delete_original_message()
         self.stop()
-    
+
     @ui.button(label='No', style=discord.ButtonStyle.red)
     async def cancel(
-        self, 
-        interaction: discord.Interaction, 
-        button: discord.Button
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button[Self],
     ) -> None:
         if interaction.message:
             await interaction.message.delete()
         else:
-            interaction.delete_original_message()
+            await interaction.delete_original_message()
         self.stop()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from discord.ext import commands
@@ -11,12 +13,12 @@ bot = CodingBot()
 
 
 @bot.before_invoke
-async def before_invoke(ctx: commands.Context):
+async def before_invoke(ctx: commands.Context[CodingBot]):
     bot.processing_commands += 1
 
 
 @bot.after_invoke
-async def after_invoke(ctx: commands.Context):
+async def after_invoke(ctx: commands.Context[CodingBot]):
     bot.processing_commands -= 1
 
 


### PR DESCRIPTION
This pull request major typing issues across the codebase. The changes done are summarised as:

- Add future annotations import to enable postponed evaluation of annotations at runtime on Python versions lower than 3.10.
- For SQLite related helpers, the arguments that used list are now using tuple instead. This was done to avoid typing issues with aiosqlite library and besides, it is conventional to use tuples instead. Note that this fix does not cause any issue at runtime and lists are safely handled.
- Typehint all bot references with `CodingBot` and `commands.Context` generic type now takes `CodingBot` 
- Add missing awaits at various places.
- Use `Optional` for parameters that use a default value of `None`.
- At some places, A type safe `discord.utils.MISSING` is used instead of `None` to avoid typing complications.
- Properly typehint late bound attributes such as `message` on `ConfirmButton` view.
- Add assertions at various places, specifically commands for type narrowing

There are some other typing issues too that aren't fixed because they have effects at runtime and unfortunately I don't have much knowledge of many internals of this bot yet so I'd prefer some person to fix those that knows how the internals work. To avoid making the scope of this PR too large, I'll open follow up PRs to fix the issues that I can fix.