### PR TITLE
Spotify and Thank Fixes

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -419,7 +419,8 @@ class Miscellaneous(commands.Cog, command_attrs=dict(hidden=False)):
         `{prefix}spotify`: *will show your spotify status*
         `{prefix}spotify [member]`: *will show the spotify status of [member]*
         """
-        member = member or ctx.author
+        member = ctx.guild.get_member((member or ctx.author).id)
+        
         spotify = Spotify(bot=self.bot, member=member)
         result = await spotify.get_embed()
         if not result:
@@ -435,6 +436,11 @@ class Miscellaneous(commands.Cog, command_attrs=dict(hidden=False)):
             )
         file, view = result
         await self.bot.send(ctx, file=file, view=view)
+
+
+    @commands.hybrid_command(name="testact")
+    async def _testact(self, ctx):
+        await ctx.send(ctx.author.activity)
 
 
 async def setup(bot: CodingBot):

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -443,10 +443,5 @@ class Miscellaneous(commands.Cog, command_attrs=dict(hidden=False)):
         await self.bot.send(ctx, file=file, view=view)
 
 
-    @commands.hybrid_command(name="testact")
-    async def _testact(self, ctx):
-        await ctx.send(ctx.author.activity)
-
-
 async def setup(bot: CodingBot):
     await bot.add_cog(Miscellaneous(bot))

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -361,7 +361,12 @@ class Miscellaneous(commands.Cog, command_attrs=dict(hidden=False)):
             )
             embeds.append(embed)
         if len(embeds) == 1:
-            paginator = pg.Paginator(self.bot, embeds, ctx)
+            paginator = pg.Paginator(
+                self.bot,
+                embeds,
+                ctx,
+                check=lambda i: i.user.id == ctx.author.id,
+                )
             paginator.add_button(
                 "delete", label="Delete", style=discord.ButtonStyle.danger
             )

--- a/ext/helpers.py
+++ b/ext/helpers.py
@@ -23,6 +23,7 @@ from ext.consts import TCR_STAFF_ROLE_ID
 
 if TYPE_CHECKING:
     from ext.models import CodingBot
+    from discord.ext import commands
 
 
 async def check_invite(bot, content, channel):
@@ -492,8 +493,8 @@ class Spotify:
         member : discord.Member
             represents the Member object whose spotify listening is to be handled
         """
-        self.member = member
-        self.bot = bot
+        self.member: discord.Member | discord.User = member
+        self.bot: commands.Bot = bot
         self.counter = 0
 
     @staticmethod


### PR DESCRIPTION
## Summary
These quick fixes are for the Spotify and thanks commands. 
- The `thank leaderboard` command no longer allows all users to delete it; only the author 
- The `Spotify` slash command now works, and added some typing to the Spotify helper class

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
